### PR TITLE
Remove type-lift

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,8 @@ an npm package from the current code into [the `npm/` directory](/npm):
 deno run -A scripts/build_npm.ts
 ```
 
-If you have an npm project setup locally for testing, you may install the built package using a local path:
+If you have an npm project setup locally for testing, you may install the built
+package using a local path:
 
 ```sh
 npm install path/to/com-plain-date/npm

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,40 @@
+# Development
+
+```sh
+# Run tests
+deno test
+
+# Linter
+deno lint
+
+# Formatter
+deno fmt --check
+deno fmt
+```
+
+## Releases
+
+Releases are to be created and managed through
+[GitHub Releases](https://github.com/bjuppa/com-plain-date/releases).
+
+New releases are automatically published to
+[deno.land](https://deno.land/x/complaindate) with a
+[GitHub Webhook](https://github.com/bjuppa/com-plain-date/settings/hooks) and to
+[npm](https://www.npmjs.com/package/complaindate) with a
+[GitHub Action](https://github.com/bjuppa/com-plain-date/actions).
+
+## Testing the package
+
+There's a script (using [dnt](https://github.com/denoland/dnt)) that generates
+an npm package from the current code into [the `npm/` directory](/npm):
+
+```sh
+# Version tag is not required for local testing
+deno run -A scripts/build_npm.ts
+```
+
+If you have an npm project setup locally for testing, you may install the built package using a local path:
+
+```sh
+npm install path/to/com-plain-date/npm
+```

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -230,5 +230,4 @@ export function ExPlainDate(
   return exPlainDate;
 }
 
-ExPlainDate.of = ExPlainDate;
 ExPlainDate.fromString = PlainDate.fromString;

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -85,8 +85,6 @@ export interface ComPlainDate {
 /** Describes a factory function that creates plain-date objects */
 export interface PlainDateFactory<T extends ComPlainDate> {
   (x: SloppyDate): T;
-  /** Type lift (unit) */
-  of: PlainDateFactory<T>;
   /** Create a new plain-date object from an ISO string */
   fromString: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
@@ -178,8 +176,6 @@ export function PlainDate(
   return plainDate;
 }
 
-PlainDate.of = PlainDate;
-
 PlainDate.fromString = function <T extends ComPlainDate>(
   this: PlainDateFactory<T>,
   isoDateString: string,
@@ -188,5 +184,5 @@ PlainDate.fromString = function <T extends ComPlainDate>(
   if (!parts) {
     throw TypeError(`No date parts found in string: ${isoDateString}`);
   }
-  return this.of(parts);
+  return this(parts);
 };

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ available — only time will tell...
 
 [API documentation at deno.land](https://deno.land/x/complaindate/mod.ts)
 
+The footprint of a tree-shaken and compressed production build starts below
+`1.5 kB` when using just the `PlainDate` object API.
+
 ## Quick example
 
 ```ts

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,18 @@
+{
+  "lock": false,
+  "lint": {
+    "exclude": [
+      "npm/"
+    ]
+  },
+  "fmt": {
+    "exclude": [
+      "npm/"
+    ]
+  },
+  "test": {
+    "exclude": [
+      "npm/"
+    ]
+  }
+}

--- a/utils/splitDateTime.ts
+++ b/utils/splitDateTime.ts
@@ -13,7 +13,7 @@ export function splitDateTime(timezone: string) {
     instant ??= new Date();
     const locale = "en";
     const options = { timeZone: timezone, hour12: false };
-    const plainDate = PlainDate.of({
+    const plainDate = PlainDate({
       year: instant.toLocaleDateString(locale, { ...options, year: "numeric" }),
       month: instant.toLocaleDateString(locale, {
         ...options,

--- a/utils/splitLocalDateTime.ts
+++ b/utils/splitLocalDateTime.ts
@@ -7,7 +7,7 @@ import { SplitDateTime } from "../support/date-time-types.ts";
  */
 export function splitLocalDateTime(instant?: Date): SplitDateTime {
   instant ??= new Date();
-  const plainDate = PlainDate.of({
+  const plainDate = PlainDate({
     year: instant.getFullYear(),
     month: instant.getMonth() + 1,
     day: instant.getDate(),

--- a/utils/splitUtcDateTime.ts
+++ b/utils/splitUtcDateTime.ts
@@ -7,7 +7,7 @@ import { SplitDateTime } from "../support/date-time-types.ts";
  */
 export function splitUtcDateTime(instant?: Date): SplitDateTime {
   instant ??= new Date();
-  const plainDate = PlainDate.of({
+  const plainDate = PlainDate({
     year: instant.getUTCFullYear(),
     month: instant.getUTCMonth() + 1,
     day: instant.getUTCDate(),


### PR DESCRIPTION
The type-lift (`of`) function on the plain-date factory prevented tree-shaking due to its self-reference. It was not really used for anything, so this PR removes it to reduce production build sizes quite significantly (`1.5k`, down from over `3k`).

Also, documents package development workflows.

Closes #10 