### PR TITLE
Optimize tree shaking

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -229,5 +229,3 @@ export function ExPlainDate(
 
   return exPlainDate;
 }
-
-ExPlainDate.fromString = PlainDate.fromString;

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -2,7 +2,7 @@ import { ComPlainDate, PlainDate } from "./PlainDate.ts";
 import { SloppyTime } from "./support/date-time-types.ts";
 import { createLocalInstant } from "./utils/createLocalInstant.ts";
 import { createInstant } from "./utils/createInstant.ts";
-import { Quarter, WeekDay } from "./constants.ts";
+import { QuarterNumber, WeekDay, WeekDayNumber } from "./constants.ts";
 import { addDays } from "./utils/addDays.ts";
 import { addBusinessDays } from "./utils/addBusinessDays.ts";
 import { addMonths } from "./utils/addMonths.ts";
@@ -48,9 +48,9 @@ export interface ExtendedPlainDate extends ComPlainDate {
   /** Day of the year (1-366) */
   ordinal: () => number;
   /** Quarter of the year (1-4) */
-  quarter: () => Quarter;
+  quarter: () => QuarterNumber;
   /** ISO weekday number (1-7) starting with Monday */
-  weekDayNumber: () => WeekDay;
+  weekDayNumber: () => WeekDayNumber;
   /** Monday to Friday */
   isBusinessDay: () => boolean;
   /** Saturday or Sunday */

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -30,6 +30,7 @@ import { isLastDayOfMonth } from "./utils/isLastDayOfMonth.ts";
 import { isFirstDayOfYear } from "./utils/isFirstDayOfYear.ts";
 import { isLastDayOfYear } from "./utils/isLastDayOfYear.ts";
 import { SloppyDate } from "./mod.ts";
+import { formatPlainDate } from "./utils/formatPlainDate.ts";
 
 /**
  * Describes an extended plain-date object with extra properties and
@@ -44,6 +45,16 @@ export interface ExtendedPlainDate extends ComPlainDate {
    * Get a native JS `Date` object in a named timezone.
    */
   toInstant: (timezone: string, time?: SloppyTime) => Date;
+
+  toLocaleStringMedium: (locale?: Intl.LocalesArgument) => string;
+  toLocaleStringLong: (locale?: Intl.LocalesArgument) => string;
+  toLocaleStringFull: (locale?: Intl.LocalesArgument) => string;
+  dayName: (locale?: Intl.LocalesArgument) => string;
+  dayNameShort: (locale?: Intl.LocalesArgument) => string;
+  dayNameNarrow: (locale?: Intl.LocalesArgument) => string;
+  monthName: (locale?: Intl.LocalesArgument) => string;
+  monthNameShort: (locale?: Intl.LocalesArgument) => string;
+  monthNameNarrow: (locale?: Intl.LocalesArgument) => string;
 
   /** Day of the year (1-366) */
   ordinal: () => number;
@@ -121,6 +132,34 @@ export function ExPlainDate(
         second,
         millisecond,
       });
+    },
+
+    toLocaleStringMedium(locale = undefined) {
+      return formatPlainDate(locale)({ dateStyle: "medium" })(this);
+    },
+    toLocaleStringLong(locale = undefined) {
+      return formatPlainDate(locale)({ dateStyle: "long" })(this);
+    },
+    toLocaleStringFull(locale = undefined) {
+      return formatPlainDate(locale)({ dateStyle: "full" })(this);
+    },
+    dayName(locale = undefined) {
+      return formatPlainDate(locale)({ weekday: "long" })(this);
+    },
+    dayNameShort(locale = undefined) {
+      return formatPlainDate(locale)({ weekday: "short" })(this);
+    },
+    dayNameNarrow(locale = undefined) {
+      return formatPlainDate(locale)({ weekday: "narrow" })(this);
+    },
+    monthName(locale = undefined) {
+      return formatPlainDate(locale)({ month: "long" })(this);
+    },
+    monthNameShort(locale = undefined) {
+      return formatPlainDate(locale)({ month: "short" })(this);
+    },
+    monthNameNarrow(locale = undefined) {
+      return formatPlainDate(locale)({ month: "narrow" })(this);
     },
 
     ordinal() {

--- a/ExPlainDate_test.ts
+++ b/ExPlainDate_test.ts
@@ -47,14 +47,6 @@ Deno.test("can be converted to instant in given timezone", () => {
   );
 });
 
-Deno.test("can be created from ISO string", () => {
-  assertEquals(String(ExPlainDate.fromString("2022-02-02")), "2022-02-02");
-});
-
-Deno.test("throws error when string only contains year part", () => {
-  assertThrows(() => ExPlainDate.fromString("2022"));
-});
-
 Deno.test("can be converted to instant in UTC", () => {
   const exPlainDate = ExPlainDate({ year: 2022, month: 2, day: 2 });
   const time = { hour: 23, minute: 59, second: 59, millisecond: 999 };

--- a/ExPlainDate_test.ts
+++ b/ExPlainDate_test.ts
@@ -57,6 +57,42 @@ Deno.test("can be converted to instant in UTC", () => {
   );
 });
 
+Deno.test("day name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 6, day: 13 });
+
+  assertEquals(exPlainDate.dayName("sv"), "lördag");
+});
+
+Deno.test("short day name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 6, day: 13 });
+
+  assertEquals(exPlainDate.dayNameShort("sv"), "lör");
+});
+
+Deno.test("narrow day name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 6, day: 13 });
+
+  assertEquals(exPlainDate.dayNameNarrow("sv"), "L");
+});
+
+Deno.test("month name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 2, day: 13 });
+
+  assertEquals(exPlainDate.monthName("sv"), "februari");
+});
+
+Deno.test("short month name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 2, day: 13 });
+
+  assertEquals(exPlainDate.monthNameShort("sv"), "feb.");
+});
+
+Deno.test("narrow month name can be localized", () => {
+  const exPlainDate = ExPlainDate({ year: 2020, month: 2, day: 13 });
+
+  assertEquals(exPlainDate.monthNameNarrow("sv"), "F");
+});
+
 Deno.test("Months and days can be added in any order with same result", () => {
   // The next month only has 28 days
   const exPlainDate = ExPlainDate({ year: 2022, month: 1, day: 31 });

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -1,7 +1,6 @@
 import { SloppyDate, SloppyTime } from "./support/date-time-types.ts";
 import { MonthNumber } from "./constants.ts";
 import { createUtcInstant } from "./utils/createUtcInstant.ts";
-import { dateParts } from "./support/dateParts.ts";
 import {
   formatPlainDate,
   FormatPlainDateOptions,
@@ -35,13 +34,13 @@ export interface ComPlainDate {
    * @example
    * ```ts
    * // "6/12/2023"
-   * PlainDate.fromString('2023-06-12').toLocaleString('en');
+   * PlainDate({ year: 2023, month: 6, day: 12 }).toLocaleString('en');
    *
    * // "6/12"
-   * PlainDate.fromString('2023-06-12').toLocaleString('en', { month: 'numeric', day: 'numeric' });
+   * PlainDate({ year: 2023, month: 6, day: 12 }).toLocaleString('en', { month: 'numeric', day: 'numeric' });
    *
    * // "June 12"
-   * PlainDate.fromString('2023-06-12').toLocaleString('en', { month: 'long', day: 'numeric' });
+   * PlainDate({ year: 2023, month: 6, day: 12 }).toLocaleString('en', { month: 'long', day: 'numeric' });
    * ```
    */
   toLocaleString: (
@@ -85,11 +84,6 @@ export interface ComPlainDate {
 /** Describes a factory function that creates plain-date objects */
 export interface PlainDateFactory<T extends ComPlainDate> {
   (x: SloppyDate): T;
-  /** Create a new plain-date object from an ISO string */
-  fromString: <T extends ComPlainDate>(
-    this: PlainDateFactory<T>,
-    s: string,
-  ) => T;
 }
 
 /**
@@ -175,14 +169,3 @@ export function PlainDate(
 
   return plainDate;
 }
-
-PlainDate.fromString = function <T extends ComPlainDate>(
-  this: PlainDateFactory<T>,
-  isoDateString: string,
-): T {
-  const parts = dateParts(isoDateString);
-  if (!parts) {
-    throw TypeError(`No date parts found in string: ${isoDateString}`);
-  }
-  return this(parts);
-};

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -47,15 +47,6 @@ export interface ComPlainDate {
     locale?: Intl.LocalesArgument,
     options?: FormatPlainDateOptions,
   ) => string;
-  toLocaleStringMedium: (locale?: Intl.LocalesArgument) => string;
-  toLocaleStringLong: (locale?: Intl.LocalesArgument) => string;
-  toLocaleStringFull: (locale?: Intl.LocalesArgument) => string;
-  dayName: (locale?: Intl.LocalesArgument) => string;
-  dayNameShort: (locale?: Intl.LocalesArgument) => string;
-  dayNameNarrow: (locale?: Intl.LocalesArgument) => string;
-  monthName: (locale?: Intl.LocalesArgument) => string;
-  monthNameShort: (locale?: Intl.LocalesArgument) => string;
-  monthNameNarrow: (locale?: Intl.LocalesArgument) => string;
 
   /**
    * Get a native JS `Date` object in UTC.
@@ -122,33 +113,6 @@ export function PlainDate(
 
     toLocaleString(locale = undefined, options = { dateStyle: "short" }) {
       return formatPlainDate(locale)(options)(this);
-    },
-    toLocaleStringMedium(locale = undefined) {
-      return formatPlainDate(locale)({ dateStyle: "medium" })(this);
-    },
-    toLocaleStringLong(locale = undefined) {
-      return formatPlainDate(locale)({ dateStyle: "long" })(this);
-    },
-    toLocaleStringFull(locale = undefined) {
-      return formatPlainDate(locale)({ dateStyle: "full" })(this);
-    },
-    dayName(locale = undefined) {
-      return formatPlainDate(locale)({ weekday: "long" })(this);
-    },
-    dayNameShort(locale = undefined) {
-      return formatPlainDate(locale)({ weekday: "short" })(this);
-    },
-    dayNameNarrow(locale = undefined) {
-      return formatPlainDate(locale)({ weekday: "narrow" })(this);
-    },
-    monthName(locale = undefined) {
-      return formatPlainDate(locale)({ month: "long" })(this);
-    },
-    monthNameShort(locale = undefined) {
-      return formatPlainDate(locale)({ month: "short" })(this);
-    },
-    monthNameNarrow(locale = undefined) {
-      return formatPlainDate(locale)({ month: "narrow" })(this);
     },
 
     toUtcInstant({ hour = 0, minute = 0, second = 0, millisecond = 0 } = {}) {

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -1,5 +1,5 @@
 import { SloppyDate, SloppyTime } from "./support/date-time-types.ts";
-import { Month } from "./constants.ts";
+import { MonthNumber } from "./constants.ts";
 import { createUtcInstant } from "./utils/createUtcInstant.ts";
 import { dateParts } from "./support/dateParts.ts";
 import {
@@ -12,7 +12,7 @@ export interface ComPlainDate {
   /** Year may be negative and up to 6 digits */
   year: number;
   /** Month (1-12) */
-  month: Month;
+  month: MonthNumber;
   /** Day in month (1-31) */
   day: number;
 
@@ -112,7 +112,7 @@ export function PlainDate(
     constructor: PlainDate,
 
     year: utcDate.getUTCFullYear(),
-    month: utcDate.getUTCMonth() + 1 as Month,
+    month: utcDate.getUTCMonth() + 1 as MonthNumber,
     day: utcDate.getUTCDate(),
 
     iso: utcDate.toISOString().split("T")[0],

--- a/PlainDate_test.ts
+++ b/PlainDate_test.ts
@@ -65,42 +65,6 @@ Deno.test("can be localized", () => {
   );
 });
 
-Deno.test("day name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 6, day: 13 });
-
-  assertEquals(plainDate.dayName("sv"), "lördag");
-});
-
-Deno.test("short day name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 6, day: 13 });
-
-  assertEquals(plainDate.dayNameShort("sv"), "lör");
-});
-
-Deno.test("narrow day name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 6, day: 13 });
-
-  assertEquals(plainDate.dayNameNarrow("sv"), "L");
-});
-
-Deno.test("month name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 2, day: 13 });
-
-  assertEquals(plainDate.monthName("sv"), "februari");
-});
-
-Deno.test("short month name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 2, day: 13 });
-
-  assertEquals(plainDate.monthNameShort("sv"), "feb.");
-});
-
-Deno.test("narrow month name can be localized", () => {
-  const plainDate = PlainDate({ year: 2020, month: 2, day: 13 });
-
-  assertEquals(plainDate.monthNameNarrow("sv"), "F");
-});
-
 Deno.test("can be converted to instant in UTC", () => {
   const plainDate = PlainDate({ year: 2022, month: 2, day: 2 });
   const time = { hour: 23, minute: 59, second: 59, millisecond: 999 };

--- a/PlainDate_test.ts
+++ b/PlainDate_test.ts
@@ -101,14 +101,6 @@ Deno.test("narrow month name can be localized", () => {
   assertEquals(plainDate.monthNameNarrow("sv"), "F");
 });
 
-Deno.test("can be created from ISO string", () => {
-  assertEquals(String(PlainDate.fromString("2022-02-02")), "2022-02-02");
-});
-
-Deno.test("throws error when string only contains year part", () => {
-  assertThrows(() => PlainDate.fromString("2022"));
-});
-
 Deno.test("can be converted to instant in UTC", () => {
   const plainDate = PlainDate({ year: 2022, month: 2, day: 2 });
   const time = { hour: 23, minute: 59, second: 59, millisecond: 999 };

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ComPlainDate is available as packages for both Deno and npm:
 - [npmjs.com/package/complaindate](https://www.npmjs.com/package/complaindate)
 
 The footprint of a tree-shaken and compressed production build starts below
-`1.5 kB` when using just the `PlainDate` object API.
+`1 kB` when using just the `PlainDate` object API.
 
 ## Quick example
 

--- a/constants.ts
+++ b/constants.ts
@@ -17,37 +17,43 @@ export const DAYS_IN_COMMON_YEAR = 365;
 /** 366 */
 export const DAYS_IN_LEAP_YEAR = DAYS_IN_COMMON_YEAR + 1;
 
+export const WeekDay = {
+  MONDAY: 1,
+  TUESDAY: 2,
+  WEDNESDAY: 3,
+  THURSDAY: 4,
+  FRIDAY: 5,
+  SATURDAY: 6,
+  SUNDAY: 7,
+} as const;
+
 /** ISO weekday number (1-7) starting with Monday */
-export enum WeekDay {
-  MONDAY = 1,
-  TUESDAY,
-  WEDNESDAY,
-  THURSDAY,
-  FRIDAY,
-  SATURDAY,
-  SUNDAY,
-}
+export type WeekDayNumber = typeof WeekDay[keyof typeof WeekDay];
+
+export const Month = {
+  JANUARY: 1,
+  FEBRUARY: 2,
+  MARCH: 3,
+  APRIL: 4,
+  MAY: 5,
+  JUNE: 6,
+  JULY: 7,
+  AUGUST: 8,
+  SEPTEMBER: 9,
+  OCTOBER: 10,
+  NOVEMBER: 11,
+  DECEMBER: 12,
+} as const;
 
 /** Month (1-12) */
-export enum Month {
-  JANUARY = 1,
-  FEBRUARY,
-  MARCH,
-  APRIL,
-  MAY,
-  JUNE,
-  JULY,
-  AUGUST,
-  SEPTEMBER,
-  OCTOBER,
-  NOVEMBER,
-  DECEMBER,
-}
+export type MonthNumber = typeof Month[keyof typeof Month];
+
+export const Quarter = {
+  Q1: 1,
+  Q2: 2,
+  Q3: 3,
+  Q4: 4,
+} as const;
 
 /** Quarter of year (1-4) */
-export enum Quarter {
-  Q1 = 1,
-  Q2,
-  Q3,
-  Q4,
-}
+export type QuarterNumber = typeof Quarter[keyof typeof Quarter];

--- a/mod.ts
+++ b/mod.ts
@@ -45,6 +45,9 @@ export type {
 
 export type { PlainDateMapFn } from "./support/function-signatures.ts";
 
+// Utils for parsing strings
+export { parsePlainDate } from "./utils/parsePlainDate.ts";
+
 // Utils for splitting native JS `Date` objects into separate date & time objects
 export { splitDateTime } from "./utils/splitDateTime.ts";
 export { splitLocalDateTime } from "./utils/splitLocalDateTime.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -34,6 +34,7 @@ export {
   Quarter,
   WeekDay,
 } from "./constants.ts";
+export type { MonthNumber, QuarterNumber, WeekDayNumber } from "./constants.ts";
 
 export type {
   SloppyDate,

--- a/utils/firstWeekDay.ts
+++ b/utils/firstWeekDay.ts
@@ -1,5 +1,5 @@
 import { ComPlainDate } from "../PlainDate.ts";
-import { DAYS_IN_WEEK, WeekDay } from "../constants.ts";
+import { DAYS_IN_WEEK, WeekDayNumber } from "../constants.ts";
 import { addDays } from "./addDays.ts";
 import { weekDayNumber } from "./weekDayNumber.ts";
 
@@ -22,7 +22,7 @@ import { weekDayNumber } from "./weekDayNumber.ts";
  * ```
  */
 export function firstWeekDay(
-  targetWeekDay: WeekDay,
+  targetWeekDay: WeekDayNumber,
 ): <T extends ComPlainDate>(date: T) => T {
   return (date) =>
     addDays(

--- a/utils/firstWeekDay_test.ts
+++ b/utils/firstWeekDay_test.ts
@@ -1,7 +1,7 @@
 import { firstWeekDay } from "./firstWeekDay.ts";
 import { assertEquals } from "../dev_deps.ts";
 import { PlainDate } from "../PlainDate.ts";
-import { WeekDay } from "../constants.ts";
+import { WeekDay, WeekDayNumber } from "../constants.ts";
 
 Deno.test("returns same day from a monday", () => {
   assertEquals(
@@ -60,7 +60,7 @@ Deno.test("returns next sunday from a monday", () => {
 Deno.test("returns sunday when given 0, even if outside range 1-7", () => {
   assertEquals(
     String(
-      firstWeekDay(0 as WeekDay)(
+      firstWeekDay(0 as WeekDayNumber)(
         PlainDate(
           // a monday
           { year: 2023, month: 1, day: 16 },
@@ -74,7 +74,7 @@ Deno.test("returns sunday when given 0, even if outside range 1-7", () => {
 Deno.test("returns monday when given 8, even if outside range 1-7", () => {
   assertEquals(
     String(
-      firstWeekDay(8 as WeekDay)(
+      firstWeekDay(8 as WeekDayNumber)(
         PlainDate(
           // a tuesday
           { year: 2023, month: 1, day: 10 },
@@ -88,7 +88,7 @@ Deno.test("returns monday when given 8, even if outside range 1-7", () => {
 Deno.test("returns saturday when given -1, even if outside range 1-7", () => {
   assertEquals(
     String(
-      firstWeekDay(-1 as WeekDay)(
+      firstWeekDay(-1 as WeekDayNumber)(
         PlainDate(
           // a sunday
           { year: 2023, month: 1, day: 8 },

--- a/utils/parsePlainDate.ts
+++ b/utils/parsePlainDate.ts
@@ -1,0 +1,13 @@
+import { ComPlainDate, PlainDate } from "../PlainDate.ts";
+import { dateParts } from "../support/dateParts.ts";
+
+/**
+ * Create a new plain-date object from an ISO date string.
+ */
+export function parsePlainDate(isoDateString: string): ComPlainDate {
+  const parts = dateParts(isoDateString);
+  if (!parts) {
+    throw TypeError(`No date parts found in string: ${isoDateString}`);
+  }
+  return PlainDate(parts);
+}

--- a/utils/parsePlainDate_test.ts
+++ b/utils/parsePlainDate_test.ts
@@ -1,0 +1,10 @@
+import { parsePlainDate } from "./parsePlainDate.ts";
+import { assertEquals, assertThrows } from "../dev_deps.ts";
+
+Deno.test("can create plain-date from ISO string", () => {
+  assertEquals(String(parsePlainDate("2022-02-02")), "2022-02-02");
+});
+
+Deno.test("throws error when string only contains year part", () => {
+  assertThrows(() => parsePlainDate("2022"));
+});

--- a/utils/quarter.ts
+++ b/utils/quarter.ts
@@ -1,9 +1,9 @@
 import { ComPlainDate } from "../PlainDate.ts";
-import { Quarter } from "../constants.ts";
+import { QuarterNumber } from "../constants.ts";
 
 /**
  * Get the quarter of the year for a plain-date.
  */
-export function quarter(date: ComPlainDate): Quarter {
-  return Math.ceil(date.month / 3) as Quarter;
+export function quarter(date: ComPlainDate): QuarterNumber {
+  return Math.ceil(date.month / 3) as QuarterNumber;
 }

--- a/utils/weekDayNumber.ts
+++ b/utils/weekDayNumber.ts
@@ -1,11 +1,11 @@
-import { DAYS_IN_WEEK, WeekDay } from "../constants.ts";
+import { DAYS_IN_WEEK, WeekDayNumber } from "../constants.ts";
 import { ComPlainDate } from "../PlainDate.ts";
 
 /**
  * Get the ISO weekday number (1-7) starting with Monday from a plain-date.
  */
-export function weekDayNumber(date: ComPlainDate): WeekDay {
+export function weekDayNumber(date: ComPlainDate): WeekDayNumber {
   return (
     (date.toUtcInstant().getUTCDay() + 6) % DAYS_IN_WEEK + 1
-  ) as WeekDay;
+  ) as WeekDayNumber;
 }


### PR DESCRIPTION
This PR reduces a compressed minimal production build to less than `1 kB`, down from `1.5 kB`!

- Use JS objects instead of TS enums to get rid of the unneccesary reverse mappings in compiled code.
- Don't put static methods on factories (they are hard to tree-shake), move them to separate utility function.
- Move utility methods for string localization to `ExPlainDate`