### PR TITLE
Reinstate fromString on ExPlainDate

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -1,5 +1,5 @@
-import { ComPlainDate, PlainDate } from "./PlainDate.ts";
-import { SloppyTime } from "./support/date-time-types.ts";
+import { ComPlainDate, PlainDate, PlainDateFactory } from "./PlainDate.ts";
+import { SloppyDate, SloppyTime } from "./support/date-time-types.ts";
 import { createLocalInstant } from "./utils/createLocalInstant.ts";
 import { createInstant } from "./utils/createInstant.ts";
 import { QuarterNumber, WeekDay, WeekDayNumber } from "./constants.ts";
@@ -29,8 +29,8 @@ import { isFirstDayOfMonth } from "./utils/isFirstDayOfMonth.ts";
 import { isLastDayOfMonth } from "./utils/isLastDayOfMonth.ts";
 import { isFirstDayOfYear } from "./utils/isFirstDayOfYear.ts";
 import { isLastDayOfYear } from "./utils/isLastDayOfYear.ts";
-import { SloppyDate } from "./mod.ts";
 import { formatPlainDate } from "./utils/formatPlainDate.ts";
+import { parsePlainDate } from "./utils/parsePlainDate.ts";
 
 /**
  * Describes an extended plain-date object with extra properties and
@@ -268,3 +268,10 @@ export function ExPlainDate(
 
   return exPlainDate;
 }
+
+ExPlainDate.fromString = function <T extends ComPlainDate>(
+  this: PlainDateFactory<T>,
+  isoDateString: string,
+): T {
+  return this(parsePlainDate(isoDateString));
+};

--- a/ExPlainDate_test.ts
+++ b/ExPlainDate_test.ts
@@ -57,6 +57,14 @@ Deno.test("can be converted to instant in UTC", () => {
   );
 });
 
+Deno.test("can be created from ISO string", () => {
+  assertEquals(String(ExPlainDate.fromString("2022-02-02")), "2022-02-02");
+});
+
+Deno.test("throws error when string only contains year part", () => {
+  assertThrows(() => ExPlainDate.fromString("2022"));
+});
+
 Deno.test("day name can be localized", () => {
   const exPlainDate = ExPlainDate({ year: 2020, month: 6, day: 13 });
 

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -75,6 +75,11 @@ export interface ComPlainDate {
 /** Describes a factory function that creates plain-date objects */
 export interface PlainDateFactory<T extends ComPlainDate> {
   (x: SloppyDate): T;
+  /** Create a new plain-date object from an ISO string */
+  fromString?: <T extends ComPlainDate>(
+    this: PlainDateFactory<T>,
+    s: string,
+  ) => T;
 }
 
 /**

--- a/constants.ts
+++ b/constants.ts
@@ -17,6 +17,7 @@ export const DAYS_IN_COMMON_YEAR = 365;
 /** 366 */
 export const DAYS_IN_LEAP_YEAR = DAYS_IN_COMMON_YEAR + 1;
 
+/** ISO weekday number (1-7) starting with Monday */
 export const WeekDay = {
   MONDAY: 1,
   TUESDAY: 2,
@@ -30,6 +31,7 @@ export const WeekDay = {
 /** ISO weekday number (1-7) starting with Monday */
 export type WeekDayNumber = typeof WeekDay[keyof typeof WeekDay];
 
+/** Month (1-12) */
 export const Month = {
   JANUARY: 1,
   FEBRUARY: 2,
@@ -48,6 +50,7 @@ export const Month = {
 /** Month (1-12) */
 export type MonthNumber = typeof Month[keyof typeof Month];
 
+/** Quarter of year (1-4) */
 export const Quarter = {
   Q1: 1,
   Q2: 2,


### PR DESCRIPTION
This PR brings back the `fromString` method to factories, but makes it optional. Now only `ExPlainDate` has it.

The previous commit that removed it was fd49ffde72de92e83ea2e845e692be2d34248a82