### PR TITLE
Provide sub-factories on ExPlainDate

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -272,6 +272,9 @@ export function ExPlainDate(
   return exPlainDate;
 }
 
+/**
+ * Create a new plain-date object from an ISO string.
+ */
 ExPlainDate.fromString = function <T extends ComPlainDate>(
   this: PlainDateFactory<T>,
   isoDateString: string,
@@ -279,6 +282,11 @@ ExPlainDate.fromString = function <T extends ComPlainDate>(
   return this(parsePlainDate(isoDateString));
 };
 
+/**
+ * Create a new plain-date object from a native JS `Date` object in UTC.
+ *
+ * @param instant Optional JS `Date`, fallback to current wall-time
+ */
 ExPlainDate.fromUtcInstant = function <T extends ComPlainDate>(
   this: PlainDateFactory<T>,
   instant?: Date,
@@ -286,6 +294,12 @@ ExPlainDate.fromUtcInstant = function <T extends ComPlainDate>(
   return this(splitUtcDateTime(instant)[0]);
 };
 
+/**
+ * Create a new plain-date object from a native JS `Date` object
+ * in the system's local timezone.
+ *
+ * @param instant Optional JS `Date`, fallback to current wall-time
+ */
 ExPlainDate.fromLocalInstant = function <T extends ComPlainDate>(
   this: PlainDateFactory<T>,
   instant?: Date,
@@ -293,6 +307,13 @@ ExPlainDate.fromLocalInstant = function <T extends ComPlainDate>(
   return this(splitLocalDateTime(instant)[0]);
 };
 
+/**
+ * Create a new plain-date object from a native JS `Date` object
+ * in a specific timezone.
+ *
+ * @param timezone A named IANA timezone
+ * @param instant Optional JS `Date`, fallback to current wall-time
+ */
 ExPlainDate.fromInstant = function <T extends ComPlainDate>(
   this: PlainDateFactory<T>,
   timezone: string,

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -31,6 +31,9 @@ import { isFirstDayOfYear } from "./utils/isFirstDayOfYear.ts";
 import { isLastDayOfYear } from "./utils/isLastDayOfYear.ts";
 import { formatPlainDate } from "./utils/formatPlainDate.ts";
 import { parsePlainDate } from "./utils/parsePlainDate.ts";
+import { splitUtcDateTime } from "./utils/splitUtcDateTime.ts";
+import { splitLocalDateTime } from "./utils/splitLocalDateTime.ts";
+import { splitDateTime } from "./utils/splitDateTime.ts";
 
 /**
  * Describes an extended plain-date object with extra properties and
@@ -274,4 +277,26 @@ ExPlainDate.fromString = function <T extends ComPlainDate>(
   isoDateString: string,
 ): T {
   return this(parsePlainDate(isoDateString));
+};
+
+ExPlainDate.fromUtcInstant = function <T extends ComPlainDate>(
+  this: PlainDateFactory<T>,
+  instant?: Date,
+): T {
+  return this(splitUtcDateTime(instant)[0]);
+};
+
+ExPlainDate.fromLocalInstant = function <T extends ComPlainDate>(
+  this: PlainDateFactory<T>,
+  instant?: Date,
+): T {
+  return this(splitLocalDateTime(instant)[0]);
+};
+
+ExPlainDate.fromInstant = function <T extends ComPlainDate>(
+  this: PlainDateFactory<T>,
+  timezone: string,
+  instant?: Date,
+): T {
+  return this(splitDateTime(timezone)(instant)[0]);
 };

--- a/ExPlainDate_test.ts
+++ b/ExPlainDate_test.ts
@@ -65,6 +65,51 @@ Deno.test("throws error when string only contains year part", () => {
   assertThrows(() => ExPlainDate.fromString("2022"));
 });
 
+Deno.test("can be created from instant in UTC", () => {
+  assertEquals(
+    String(ExPlainDate.fromUtcInstant(new Date("2022-02-02T00:00:00Z"))),
+    "2022-02-02",
+  );
+});
+
+Deno.test("can be created from current wall-time in UTC", () => {
+  assertEquals(
+    String(ExPlainDate.fromUtcInstant(new Date())),
+    new Date().toLocaleDateString("sv", { timeZone: "UTC" }),
+  );
+});
+
+Deno.test("can be created from instant in system's local timezone", () => {
+  assertEquals(
+    String(ExPlainDate.fromLocalInstant(new Date("2022-02-02T00:00:00"))),
+    "2022-02-02",
+  );
+});
+
+Deno.test("can be created from current wall-time in system's local timezone", () => {
+  assertEquals(
+    String(ExPlainDate.fromLocalInstant()),
+    new Date().toLocaleDateString("sv"),
+  );
+});
+
+Deno.test("can be created from instant in a specific timezone", () => {
+  assertEquals(
+    String(
+      ExPlainDate.fromInstant("Asia/Tokyo", new Date("2022-02-02T00:00+0900")),
+    ),
+    "2022-02-02",
+  );
+});
+
+Deno.test("can be created from current wall-time in a specific timezone", () => {
+  const tz = "Asia/Tokyo";
+  assertEquals(
+    String(ExPlainDate.fromInstant(tz, new Date())),
+    new Date().toLocaleDateString("sv", { timeZone: tz }),
+  );
+});
+
 Deno.test("day name can be localized", () => {
   const exPlainDate = ExPlainDate({ year: 2020, month: 6, day: 13 });
 

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -72,45 +72,26 @@ export interface ComPlainDate {
   ) => T;
 }
 
-/** Describes a factory function that creates plain-date objects */
+/**
+ * Describes a factory function that creates plain-date objects.
+ *
+ * Specific implementations of the factory may provide additional methods that
+ * takes other kinds of arguments.
+ */
 export interface PlainDateFactory<T extends ComPlainDate> {
-  /** Callable signature */
   (x: SloppyDate): T;
-
-  /** Create a new plain-date object from an ISO string */
   fromString?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     s: string,
   ) => T;
-
-  /**
-   * Create a new plain-date object from a native JS `Date` object in UTC.
-   *
-   * @param instant Optional JS `Date`, fallback to current wall-time
-   */
   fromUtcInstant?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     instant?: Date,
   ) => T;
-
-  /**
-   * Create a new plain-date object from a native JS `Date` object
-   * in the system's local timezone.
-   *
-   * @param instant Optional JS `Date`, fallback to current wall-time
-   */
   fromLocalInstant?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     instant?: Date,
   ) => T;
-
-  /**
-   * Create a new plain-date object from a native JS `Date` object
-   * in a specific timezone.
-   *
-   * @param timezone A named IANA timezone
-   * @param instant Optional JS `Date`, fallback to current wall-time
-   */
   fromInstant?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     timezone: string,

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -74,11 +74,47 @@ export interface ComPlainDate {
 
 /** Describes a factory function that creates plain-date objects */
 export interface PlainDateFactory<T extends ComPlainDate> {
+  /** Callable signature */
   (x: SloppyDate): T;
+
   /** Create a new plain-date object from an ISO string */
   fromString?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     s: string,
+  ) => T;
+
+  /**
+   * Create a new plain-date object from a native JS `Date` object in UTC.
+   *
+   * @param instant Optional JS `Date`, fallback to current wall-time
+   */
+  fromUtcInstant?: <T extends ComPlainDate>(
+    this: PlainDateFactory<T>,
+    instant?: Date,
+  ) => T;
+
+  /**
+   * Create a new plain-date object from a native JS `Date` object
+   * in the system's local timezone.
+   *
+   * @param instant Optional JS `Date`, fallback to current wall-time
+   */
+  fromLocalInstant?: <T extends ComPlainDate>(
+    this: PlainDateFactory<T>,
+    instant?: Date,
+  ) => T;
+
+  /**
+   * Create a new plain-date object from a native JS `Date` object
+   * in a specific timezone.
+   *
+   * @param timezone A named IANA timezone
+   * @param instant Optional JS `Date`, fallback to current wall-time
+   */
+  fromInstant?: <T extends ComPlainDate>(
+    this: PlainDateFactory<T>,
+    timezone: string,
+    instant?: Date,
   ) => T;
 }
 


### PR DESCRIPTION
Implements `fromUtcInstant`, `fromLocalInstant` & `fromInstant` on `ExPlainDate`.