### PR TITLE
Cleanup format utils

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -79,6 +79,7 @@ export { startOfYear } from "./utils/startOfYear.ts";
 export { datetimeLocal } from "./utils/datetimeLocal.ts";
 export { formatPlainDate } from "./utils/formatPlainDate.ts";
 export { formatPlainTime } from "./utils/formatPlainTime.ts";
+export { formatInstant } from "./utils/formatInstant.ts";
 
 // Utils for getting information about a date object
 export { daysInMonth } from "./utils/daysInMonth.ts";

--- a/utils/formatInstant.ts
+++ b/utils/formatInstant.ts
@@ -14,11 +14,11 @@
  *
  * @example
  * ```ts
- * const formatInstantDefault = formatInstant()()("Europe/Stockholm"); // Use system's locale and default formatting options
- * const formatInstant24h = formatInstant("en")({ hourCycle: "h23" })("Europe/Stockholm");
+ * const formatDateTime = formatInstant()()("Europe/Stockholm"); // Use system's locale and default formatting options
+ * const format24hDateTime = formatInstant("en")({ hourCycle: "h23" })("Europe/Stockholm");
  *
- * formatInstantDefault(new Date()); // "6/11/2023, 4:54:32 PM GMT+2"
- * formatInstant24h(new Date());  // "6/11/2023, 16:54:32"
+ * formatDateTime(new Date()); // "6/11/2023, 4:54:32 PM GMT+2"
+ * format24hDateTime(new Date());  // "6/11/2023, 16:54:32"
  * ```
  */
 export function formatInstant(locale: Intl.LocalesArgument = undefined) {

--- a/utils/formatInstant.ts
+++ b/utils/formatInstant.ts
@@ -1,3 +1,5 @@
+export type FormatInstantOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
+
 /**
  * Curry a function to get localized strings of its JS `Date` arguments.
  *
@@ -21,13 +23,10 @@
  * format24hDateTime(new Date());  // "6/11/2023, 16:54:32"
  * ```
  */
-export function formatInstant(locale: Intl.LocalesArgument = undefined) {
-  return (options: Omit<
-    Intl.DateTimeFormatOptions,
-    "timeZone"
-  > = { timeZoneName: "short" }) =>
-  (timezone: string) =>
-  (instant: Date): string =>
+export function formatInstant(locale: Intl.LocalesArgument = undefined): (
+  options?: FormatInstantOptions,
+) => (timezone: string) => (instant: Date) => string {
+  return (options = { timeZoneName: "short" }) => (timezone) => (instant) =>
     instant.toLocaleString(locale, {
       ...options,
       timeZone: timezone,

--- a/utils/formatPlainDate.ts
+++ b/utils/formatPlainDate.ts
@@ -15,11 +15,11 @@ import { ComPlainDate, FormatPlainDateOptions } from "../PlainDate.ts";
  *
  * @example
  * ```ts
- * const formatPlainDateDefault = formatPlainDate()(); // Use system's locale and default formatting options
- * const formatPlainDateMonthAndDay = formatPlainDate("en")({ month: "long", day: "numeric" });
+ * const formatDate = formatPlainDate()(); // Use system's locale and default formatting options
+ * const formatMonthAndDay = formatPlainDate("en")({ month: "long", day: "numeric" });
  *
- * formatPlainDateDefault(PlainDate({ year: 2023 })); // "1/1/2023"
- * formatPlainDateMonthAndDay(PlainDate({ year: 2023 }));  // "January 1"
+ * formatDate(PlainDate({ year: 2023 })); // "1/1/2023"
+ * formatMonthAndDay(PlainDate({ year: 2023 }));  // "January 1"
  * ```
  */
 export function formatPlainDate(locale: Intl.LocalesArgument = undefined) {

--- a/utils/formatPlainDate.ts
+++ b/utils/formatPlainDate.ts
@@ -22,7 +22,8 @@ import { ComPlainDate, FormatPlainDateOptions } from "../PlainDate.ts";
  * formatMonthAndDay(PlainDate({ year: 2023 }));  // "January 1"
  * ```
  */
-export function formatPlainDate(locale: Intl.LocalesArgument = undefined) {
-  return (options: FormatPlainDateOptions = {}) =>
-  (date: ComPlainDate): string => date.toLocaleString(locale, options);
+export function formatPlainDate(
+  locale: Intl.LocalesArgument = undefined,
+): (options?: FormatPlainDateOptions) => (date: ComPlainDate) => string {
+  return (options = {}) => (date) => date.toLocaleString(locale, options);
 }

--- a/utils/formatPlainTime.ts
+++ b/utils/formatPlainTime.ts
@@ -22,7 +22,8 @@ import { ComPlainTime, FormatPlainTimeOptions } from "../PlainTime.ts";
  * formatHour(PlainTime({ hour: 13, minute: 37 }));  // "1 PM"
  * ```
  */
-export function formatPlainTime(locale: Intl.LocalesArgument = undefined) {
-  return (options: FormatPlainTimeOptions = {}) =>
-  (time: ComPlainTime): string => time.toLocaleString(locale, options);
+export function formatPlainTime(
+  locale: Intl.LocalesArgument = undefined,
+): (options?: FormatPlainTimeOptions) => (time: ComPlainTime) => string {
+  return (options = {}) => (time) => time.toLocaleString(locale, options);
 }

--- a/utils/formatPlainTime.ts
+++ b/utils/formatPlainTime.ts
@@ -15,11 +15,11 @@ import { ComPlainTime, FormatPlainTimeOptions } from "../PlainTime.ts";
  *
  * @example
  * ```ts
- * const formatPlainTimeDefault = formatPlainTime()(); // Use system's locale and default formatting options
- * const formatPlainTimeHour = formatPlainTime("en")({ hour: "numeric" });
+ * const formatTime = formatPlainTime()(); // Use system's locale and default formatting options
+ * const formatHour = formatPlainTime("en")({ hour: "numeric" });
  *
- * formatPlainTimeDefault(PlainTime({ hour: 13, minute: 37 })); // "1:37:00 PM"
- * formatPlainTimeHour(PlainTime({ hour: 13, minute: 37 }));  // "1 PM"
+ * formatTime(PlainTime({ hour: 13, minute: 37 })); // "1:37:00 PM"
+ * formatHour(PlainTime({ hour: 13, minute: 37 }));  // "1 PM"
  * ```
  */
 export function formatPlainTime(locale: Intl.LocalesArgument = undefined) {


### PR DESCRIPTION
This PR adds the previously missing export of `formatInstant` from the module.

Also, suggest better userland naming of curried functions in examples and adds explicit return types for the Deno docs generator to pick up.