### PR TITLE
Remove 0 params

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -204,16 +204,16 @@ export function ExPlainDate(
       return daysInMonth(this);
     },
 
-    addDays(days = 0) {
+    addDays(days) {
       return addDays(days)(this);
     },
-    addBusinessDays(days = 0) {
+    addBusinessDays(days) {
       return addBusinessDays(days)(this);
     },
-    addMonths(months = 0) {
+    addMonths(months) {
       return addMonths(months)(this);
     },
-    addYears(years = 0) {
+    addYears(years) {
       return addYears(years)(this);
     },
 

--- a/utils/addDays.ts
+++ b/utils/addDays.ts
@@ -4,9 +4,9 @@ import { ComPlainDate } from "../PlainDate.ts";
  * Get a function curried with a number of days
  * to add to its plain-date arguments.
  *
- * @param {number} days The number of days to add or subtract
+ * @param days The number of days to add or subtract
  * @returns A curried function that operates on plain-dates
  */
-export function addDays(days = 0): <T extends ComPlainDate>(date: T) => T {
+export function addDays(days: number): <T extends ComPlainDate>(date: T) => T {
   return (date) => date.map((x) => ({ ...x, day: x.day + days }));
 }

--- a/utils/addMonths.ts
+++ b/utils/addMonths.ts
@@ -9,10 +9,12 @@ import { startOfMonth } from "./startOfMonth.ts";
  * The resulting day-of-month will always be within the expected month,
  * days will not spill over into the next month.
  *
- * @param {number} months The number of months to add or subtract
+ * @param months The number of months to add or subtract
  * @returns A curried function that operates on plain-dates
  */
-export function addMonths(months = 0): <T extends ComPlainDate>(date: T) => T {
+export function addMonths(
+  months: number,
+): <T extends ComPlainDate>(date: T) => T {
   return (date) =>
     date
       .map((x) => ({ ...x, month: x.month + months }))

--- a/utils/addYears.ts
+++ b/utils/addYears.ts
@@ -3,9 +3,11 @@ import { ComPlainDate } from "../PlainDate.ts";
 /**
  * Get a function curried with a number of years to add to its plain-date arguments.
  *
- * @param {number} years The number of years to add or subtract
+ * @param years The number of years to add or subtract
  * @returns A curried function that operates on plain-dates
  */
-export function addYears(years = 0): <T extends ComPlainDate>(date: T) => T {
+export function addYears(
+  years: number,
+): <T extends ComPlainDate>(date: T) => T {
   return (date) => date.map((x) => ({ ...x, year: x.year + years }));
 }


### PR DESCRIPTION
Default `0` function parameters confuses the docs-generator, and doesn't really help IDE:s that doesn't pick up typescript typing anyway.