### PR TITLE
Abandoned idea: Avoid destructured function params with default values

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -114,29 +114,16 @@ export interface ExtendedPlainDate extends ComPlainDate {
  * @param date A date object with properties `year`, `month` & `day`
  * @returns A new immutable extended plain-date object
  */
-export function ExPlainDate(
-  { year = NaN, month = 1, day = 1 }: SloppyDate,
-): ExtendedPlainDate {
+export function ExPlainDate(date: SloppyDate): ExtendedPlainDate {
   const exPlainDate: ExtendedPlainDate = {
-    ...PlainDate({ year, month, day }),
+    ...PlainDate(date),
     constructor: ExPlainDate,
 
-    toLocalInstant(
-      { hour = 0, minute = 0, second = 0, millisecond = 0 } = {},
-    ) {
-      return createLocalInstant({ ...this, hour, minute, second, millisecond });
+    toLocalInstant(time = {}) {
+      return createLocalInstant({ ...this, ...time });
     },
-    toInstant(
-      timezone,
-      { hour = 0, minute = 0, second = 0, millisecond = 0 } = {},
-    ) {
-      return createInstant(timezone)({
-        ...this,
-        hour,
-        minute,
-        second,
-        millisecond,
-      });
+    toInstant(timezone, time = {}) {
+      return createInstant(timezone)({ ...this, ...time });
     },
 
     toLocaleStringMedium(locale = undefined) {

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -111,15 +111,11 @@ export interface PlainDateFactory<T extends ComPlainDate> {
  * @param date A date object with properties `year`, `month` & `day`
  * @returns A new immutable plain-date object
  */
-export function PlainDate(
-  { year = NaN, month = 1, day = 1 }: SloppyDate,
-): ComPlainDate {
-  const utcDate = createUtcInstant({ year, month, day });
+export function PlainDate(date: SloppyDate): ComPlainDate {
+  const utcDate = createUtcInstant(date);
 
   if (isNaN(utcDate.valueOf())) {
-    throw new RangeError(
-      `Input is not a valid date: ${JSON.stringify({ year, month, day })}`,
-    );
+    throw new RangeError(`Input is not a valid date: ${JSON.stringify(date)}`);
   }
 
   const plainDate: ComPlainDate = {

--- a/PlainTime.ts
+++ b/PlainTime.ts
@@ -79,23 +79,17 @@ export interface PlainTimeFactory<T extends ComPlainTime> {
  * @throws {RangeError} Input total must be less than 24 hours
  * @throws {RangeError} Input total can't be negative
  */
-export function PlainTime(
-  { hour = 0, minute = 0, second = 0, millisecond = 0 }: SloppyTime,
-): ComPlainTime {
-  const ms = tallyMilliseconds({ hour, minute, second, millisecond });
+export function PlainTime(time: SloppyTime): ComPlainTime {
+  const ms = tallyMilliseconds(time);
 
   if (ms < 0) {
     throw new RangeError(
-      `Input must be positive: ${
-        JSON.stringify({ hour, minute, second, millisecond })
-      }`,
+      `Input must be positive: ${JSON.stringify(time)}`,
     );
   }
   if (ms >= HOURS_IN_DAY * MS_IN_HOUR) {
     throw new RangeError(
-      `Input must be less than 24 hours: ${
-        JSON.stringify({ hour, minute, second, millisecond })
-      }`,
+      `Input must be less than 24 hours: ${JSON.stringify(time)}`,
     );
   }
 

--- a/support/tallyMilliseconds.ts
+++ b/support/tallyMilliseconds.ts
@@ -3,13 +3,10 @@ import { SloppyTime } from "./date-time-types.ts";
 
 /**
  * Convert a sloppy time object to a total number of milliseconds.
+ *
+ * @param time Object of hour, minute, second & millisecond, where each may be negative
  */
-export function tallyMilliseconds({
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-}: SloppyTime): number {
-  return Number(hour) * MS_IN_HOUR + Number(minute) * MS_IN_MINUTE +
-    Number(second) * MS_IN_SECOND + Number(millisecond);
+export function tallyMilliseconds(time: SloppyTime): number {
+  return Number(time.hour) * MS_IN_HOUR + Number(time.minute) * MS_IN_MINUTE +
+    Number(time.second) * MS_IN_SECOND + Number(time.millisecond);
 }

--- a/support/tallyMilliseconds.ts
+++ b/support/tallyMilliseconds.ts
@@ -7,6 +7,8 @@ import { SloppyTime } from "./date-time-types.ts";
  * @param time Object of hour, minute, second & millisecond, where each may be negative
  */
 export function tallyMilliseconds(time: SloppyTime): number {
-  return Number(time.hour) * MS_IN_HOUR + Number(time.minute) * MS_IN_MINUTE +
-    Number(time.second) * MS_IN_SECOND + Number(time.millisecond);
+  return Number(time.hour || 0) * MS_IN_HOUR +
+    Number(time.minute || 0) * MS_IN_MINUTE +
+    Number(time.second || 0) * MS_IN_SECOND +
+    Number(time.millisecond || 0);
 }

--- a/support/tallyMilliseconds_test.ts
+++ b/support/tallyMilliseconds_test.ts
@@ -14,3 +14,7 @@ Deno.test("takes negative parts", () => {
     (60 * 60 + 60 + 1) * -1000 - 1,
   );
 });
+
+Deno.test("takes undefined values", () => {
+  assertEquals(tallyMilliseconds({}), 0);
+});

--- a/utils/addTime.ts
+++ b/utils/addTime.ts
@@ -5,7 +5,7 @@ import { tallyMilliseconds } from "../support/tallyMilliseconds.ts";
  * Get a function curried with a time duration
  * to add to its native JS `Date` arguments.
  *
- * @param duration Object of hour, minute, second & millisecond, where each may be negative
+ * @param {SloppyTime} duration Object of hour, minute, second & millisecond, where each may be negative
  * @returns A curried function that operates on JS `Date` objects
  */
 export function addTime({

--- a/utils/addTime.ts
+++ b/utils/addTime.ts
@@ -5,18 +5,10 @@ import { tallyMilliseconds } from "../support/tallyMilliseconds.ts";
  * Get a function curried with a time duration
  * to add to its native JS `Date` arguments.
  *
- * @param {SloppyTime} duration Object of hour, minute, second & millisecond, where each may be negative
+ * @param time Object of hour, minute, second & millisecond, where each may be negative
  * @returns A curried function that operates on JS `Date` objects
  */
-export function addTime({
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-}: SloppyTime) {
+export function addTime(time: SloppyTime) {
   return (instant: Date): Date =>
-    new Date(
-      instant.valueOf() +
-        tallyMilliseconds({ hour, minute, second, millisecond }),
-    );
+    new Date(instant.valueOf() + tallyMilliseconds(time));
 }

--- a/utils/createInstant.ts
+++ b/utils/createInstant.ts
@@ -27,20 +27,17 @@ const intlOptions: Intl.DateTimeFormatOptions = {
  */
 export function createInstant(
   timezone: string,
-): (
-  { year, month, day, hour, minute, second, millisecond }: SloppyDateTime,
-) => Date {
-  return (
-    {
-      year = NaN,
+): (dateTime: SloppyDateTime) => Date {
+  return (dateTime) => {
+    const {
+      year,
       month = 1,
       day = 1,
       hour = 0,
       minute = 0,
       second = 0,
       millisecond = 0,
-    },
-  ) => {
+    } = dateTime;
     const intlUtcFormat = Intl.DateTimeFormat("en", {
       ...intlOptions,
       timeZone: "UTC",

--- a/utils/createLocalInstant.ts
+++ b/utils/createLocalInstant.ts
@@ -3,16 +3,19 @@ import { SloppyDateTime } from "../support/date-time-types.ts";
 /**
  * Create a native JS `Date` object from a date-time
  * interpreted in the system's local timezone.
+ *
+ * @param dateTime Object of year, month, day, hour, minute, second & millisecond
  */
-export function createLocalInstant({
-  year = NaN,
-  month = 1,
-  day = 1,
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-}: SloppyDateTime): Date {
+export function createLocalInstant(dateTime: SloppyDateTime): Date {
+  const {
+    year,
+    month = 1,
+    day = 1,
+    hour = 0,
+    minute = 0,
+    second = 0,
+    millisecond = 0,
+  } = dateTime;
   const localDate = new Date(0);
   localDate.setFullYear(Number(year), Number(month) - 1, Number(day));
   localDate.setHours(

--- a/utils/createUtcInstant.ts
+++ b/utils/createUtcInstant.ts
@@ -2,16 +2,19 @@ import { SloppyDateTime } from "../support/date-time-types.ts";
 
 /**
  * Create a native JS `Date` object from a date-time interpreted in UTC.
+ *
+ * @param dateTime Object of year, month, day, hour, minute, second & millisecond
  */
-export function createUtcInstant({
-  year = NaN,
-  month = 1,
-  day = 1,
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-}: SloppyDateTime): Date {
+export function createUtcInstant(dateTime: SloppyDateTime): Date {
+  const {
+    year,
+    month = 1,
+    day = 1,
+    hour = 0,
+    minute = 0,
+    second = 0,
+    millisecond = 0,
+  } = dateTime;
   const utcDate = new Date(0);
   utcDate.setUTCFullYear(Number(year), Number(month) - 1, Number(day));
   utcDate.setUTCHours(

--- a/utils/datetimeLocal.ts
+++ b/utils/datetimeLocal.ts
@@ -4,29 +4,18 @@ import { createUtcInstant } from "./createUtcInstant.ts";
 /**
  * Format a string suitable for HTML datetime-local inputs from a date-time object.
  *
+ * @param dateTime Object of year, month, day, hour, minute, second & millisecond
  * @returns A string in format `yyyy-mm-ddThh:mm`
  *
  * @throws {RangeError} Year must be after year 0
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local | HTML input datetime-local on MDN}
  */
-export function datetimeLocal({
-  year = NaN,
-  month = 1,
-  day = 1,
-  hour = 0,
-  minute = 0,
-}: SloppyDateTime): string {
-  if (Number(year) < 1) {
+export function datetimeLocal(dateTime: SloppyDateTime): string {
+  if (Number(dateTime.year) < 1) {
     throw new RangeError(
-      `Years before 0001 can't be represented by HTML datetime-local: ${year}`,
+      `Years before 0001 can't be represented by HTML datetime-local: ${dateTime.year}`,
     );
   }
-  const utcRepresentation = createUtcInstant({
-    year,
-    month,
-    day,
-    hour,
-    minute,
-  });
+  const utcRepresentation = createUtcInstant(dateTime);
   return utcRepresentation.toISOString().replace("+", "").slice(0, -8);
 }

--- a/utils/daysInMonth.ts
+++ b/utils/daysInMonth.ts
@@ -5,7 +5,9 @@ import { SloppyDate } from "../support/date-time-types.ts";
  * Get the number of days in a month for a given year.
  *
  * February has 29 days in a leap year, otherwise 28.
+ *
+ * @param date Object of year & month
  */
-export function daysInMonth({ year, month }: SloppyDate): number {
-  return 32 - PlainDate({ year, month, day: 32 }).day;
+export function daysInMonth(date: SloppyDate): number {
+  return 32 - PlainDate({ ...date, day: 32 }).day;
 }

--- a/utils/daysInYear.ts
+++ b/utils/daysInYear.ts
@@ -6,7 +6,9 @@ import { SloppyDate } from "../support/date-time-types.ts";
  * Get the number of days in a given year.
  *
  * Leap years have 366 days, otherwise 365.
+ *
+ * @param date Object of year
  */
-export function daysInYear({ year }: SloppyDate): number {
-  return isLeapYear({ year }) ? DAYS_IN_LEAP_YEAR : DAYS_IN_COMMON_YEAR;
+export function daysInYear(date: SloppyDate): number {
+  return isLeapYear(date) ? DAYS_IN_LEAP_YEAR : DAYS_IN_COMMON_YEAR;
 }

--- a/utils/isFirstDayOfMonth.ts
+++ b/utils/isFirstDayOfMonth.ts
@@ -2,7 +2,9 @@ import { SloppyDate } from "../support/date-time-types.ts";
 
 /**
  * Check if a date is the first day of its month.
+ *
+ * @param date Object of day
  */
-export function isFirstDayOfMonth({ day }: SloppyDate): boolean {
-  return Number(day) === 1;
+export function isFirstDayOfMonth(date: SloppyDate): boolean {
+  return Number(date.day) === 1;
 }

--- a/utils/isFirstDayOfYear.ts
+++ b/utils/isFirstDayOfYear.ts
@@ -2,7 +2,9 @@ import { SloppyDate } from "../support/date-time-types.ts";
 
 /**
  * Check if a date is the first day of its year.
+ *
+ * @param date Object of month & day
  */
-export function isFirstDayOfYear({ month, day }: Partial<SloppyDate>): boolean {
-  return Number(month) === 1 && Number(day) === 1;
+export function isFirstDayOfYear(date: Partial<SloppyDate>): boolean {
+  return Number(date.month) === 1 && Number(date.day) === 1;
 }

--- a/utils/isLastDayOfYear.ts
+++ b/utils/isLastDayOfYear.ts
@@ -2,7 +2,9 @@ import { SloppyDate } from "../support/date-time-types.ts";
 
 /**
  * Check if a date is the last day of its year.
+ *
+ * @param date Object of month & day
  */
-export function isLastDayOfYear({ month, day }: Partial<SloppyDate>): boolean {
-  return Number(month) === 12 && Number(day) === 31;
+export function isLastDayOfYear(date: Partial<SloppyDate>): boolean {
+  return Number(date.month) === 12 && Number(date.day) === 31;
 }

--- a/utils/isLeapYear.ts
+++ b/utils/isLeapYear.ts
@@ -3,7 +3,9 @@ import { createUtcInstant } from "./createUtcInstant.ts";
 
 /**
  * Check if a date is in a leap year.
+ *
+ * @param date Object of year
  */
-export function isLeapYear({ year }: SloppyDate): boolean {
-  return createUtcInstant({ year, month: 2, day: 29 }).getUTCDate() === 29;
+export function isLeapYear(date: SloppyDate): boolean {
+  return createUtcInstant({ ...date, month: 2, day: 29 }).getUTCDate() === 29;
 }

--- a/utils/subtractTime.ts
+++ b/utils/subtractTime.ts
@@ -5,18 +5,10 @@ import { tallyMilliseconds } from "../support/tallyMilliseconds.ts";
  * Get a function curried with a time duration to subtract
  * from its native JS `Date` arguments.
  *
- * @param duration Object of hour, minute, second & millisecond, where each may be negative
+ * @param time Object of hour, minute, second & millisecond, where each may be negative
  * @returns A curried function that operates on JS `Date` objects
  */
-export function subtractTime({
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-}: SloppyTime) {
+export function subtractTime(time: SloppyTime) {
   return (instant: Date): Date =>
-    new Date(
-      instant.valueOf() -
-        tallyMilliseconds({ hour, minute, second, millisecond }),
-    );
+    new Date(instant.valueOf() - tallyMilliseconds(time));
 }


### PR DESCRIPTION
This idea was explored to generate better docs, but it's no good.

The problem I wanted to solve is the `unnamed 0` in the docs of this release:
https://deno.land/x/complaindate@v0.5.7/mod.ts?s=addTime

...and the changes do make the docs for this release look better, the parameter now has a name:
https://deno.land/x/complaindate@v0.5.8/mod.ts?s=addTime
...but we loose the nice information about the shape of the expected object in IDE tools :(

And we still don't get a nice description of the shape in the docs, where that would be really helpful!

All in all, this is PR is a step back and should not be merged!