### PR TITLE
Bugfix: Handle utc offset with colon

### DIFF
--- a/utils/parseTimezone.ts
+++ b/utils/parseTimezone.ts
@@ -31,7 +31,7 @@ export function parseTimezone(timezoneString: string): string {
   }
 
   if (
-    timezoneString.match(/UTC(?!\s*[+-]\d*[1-9])/) ||
+    timezoneString.match(/UTC(?!\s*[+-][\d:]*[1-9])/) ||
     timezoneString.match(/\dZ$/)
   ) {
     return "UTC";

--- a/utils/parseTimezone_test.ts
+++ b/utils/parseTimezone_test.ts
@@ -49,11 +49,18 @@ Deno.test("UTC with 0 offset is extracted", () => {
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC+0, be there!"),
     "UTC",
   );
+  assertEquals(
+    parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC+00:00, be there!"),
+    "UTC",
+  );
 });
 
 Deno.test("UTC with positive offset is not extracted", () => {
   assertThrows(() =>
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC+01, be there!")
+  );
+  assertThrows(() =>
+    parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC+00:30, be there!")
   );
   assertThrows(() =>
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC +1, be there!")
@@ -63,6 +70,9 @@ Deno.test("UTC with positive offset is not extracted", () => {
 Deno.test("UTC with negative offset is not extracted", () => {
   assertThrows(() =>
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC-01, be there!")
+  );
+  assertThrows(() =>
+    parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC-00:30, be there!")
   );
   assertThrows(() =>
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC -1, be there!")

--- a/utils/parseTimezone_test.ts
+++ b/utils/parseTimezone_test.ts
@@ -44,6 +44,10 @@ Deno.test("UTC is extracted", () => {
   );
 });
 
+Deno.test("UTC is extracted when before a local time", () => {
+  assertEquals(parseTimezone("UTC 20:06:13"), "UTC");
+});
+
 Deno.test("UTC with 0 offset is extracted", () => {
   assertEquals(
     parseTimezone("The meeting is at 2020-08-05T20:06:13 UTC+0, be there!"),


### PR DESCRIPTION
Fix a bug where `2020-08-05T20:06:13 UTC+00:30` was erroneously extracted as `UTC` even though it has a 30 minute offset after the colon.