### PR TITLE
Rename format datetime-local function

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -76,7 +76,7 @@ export { startOfWeekend } from "./utils/startOfWeekend.ts";
 export { startOfYear } from "./utils/startOfYear.ts";
 
 // Utils for making strings
-export { datetimeLocal } from "./utils/datetimeLocal.ts";
+export { formatDatetimeLocal } from "./utils/formatDatetimeLocal.ts";
 export { formatPlainDate } from "./utils/formatPlainDate.ts";
 export { formatPlainTime } from "./utils/formatPlainTime.ts";
 export { formatInstant } from "./utils/formatInstant.ts";

--- a/utils/formatDatetimeLocal.ts
+++ b/utils/formatDatetimeLocal.ts
@@ -9,7 +9,7 @@ import { createUtcInstant } from "./createUtcInstant.ts";
  * @throws {RangeError} Year must be after year 0
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local | HTML input datetime-local on MDN}
  */
-export function datetimeLocal({
+export function formatDatetimeLocal({
   year = NaN,
   month = 1,
   day = 1,

--- a/utils/formatDatetimeLocal_test.ts
+++ b/utils/formatDatetimeLocal_test.ts
@@ -1,9 +1,9 @@
-import { datetimeLocal } from "./datetimeLocal.ts";
+import { formatDatetimeLocal } from "./formatDatetimeLocal.ts";
 import { assertEquals, assertThrows } from "../dev_deps.ts";
 
 Deno.test("formats string for HTML datetime-local input", () => {
   assertEquals(
-    datetimeLocal({
+    formatDatetimeLocal({
       year: 2022,
       month: 2,
       day: 3,
@@ -16,7 +16,7 @@ Deno.test("formats string for HTML datetime-local input", () => {
 
 Deno.test("cuts off second and millisecond", () => {
   assertEquals(
-    datetimeLocal({
+    formatDatetimeLocal({
       year: 2022,
       month: 2,
       day: 3,
@@ -31,7 +31,7 @@ Deno.test("cuts off second and millisecond", () => {
 
 Deno.test("takes 6-digit year", () => {
   assertEquals(
-    datetimeLocal({
+    formatDatetimeLocal({
       year: 100000,
     }),
     "100000-01-01T00:00",
@@ -40,6 +40,6 @@ Deno.test("takes 6-digit year", () => {
 
 Deno.test("throws error if year is less than 1 and thus can't be handled by HTML datetime-local", () => {
   assertThrows(() => {
-    datetimeLocal({ year: 0 });
+    formatDatetimeLocal({ year: 0 });
   });
 });

--- a/utils/formatTimezone.ts
+++ b/utils/formatTimezone.ts
@@ -1,5 +1,7 @@
 /**
  * Format a timezone for display to a user.
+ *
+ * @category Timezones
  */
 export function formatTimezone(timezone: string): string {
   return timezone.replaceAll("_", " ");


### PR DESCRIPTION
Make all the formatting functions actually start with "format".

Note: this is a breaking change.