### PR TITLE
Rework format instant

### DIFF
--- a/utils/formatInstant.ts
+++ b/utils/formatInstant.ts
@@ -25,7 +25,7 @@ export type FormatInstantOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
  * format24hDateTime(new Date());  // "6/11/2023, 16:54:32"
  * ```
  */
-export function formatInstant(locale: Intl.LocalesArgument = undefined): (
+export function formatInstant(locale?: Intl.LocalesArgument): (
   options?: FormatInstantOptions,
 ) => (timezone?: string) => (instant: Date) => string {
   return (options = { timeZoneName: "short" }) => (timezone) => (instant) =>

--- a/utils/formatInstant.ts
+++ b/utils/formatInstant.ts
@@ -9,7 +9,7 @@ export type FormatInstantOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
  *    defaults to system's locale if not given.
  * 2. `Intl` {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat | format options },
  *    defaults to include a "short" timezone-style if no options given.
- * 3. A named IANA timezone.
+ * 3. A named IANA timezone, defaults to system's timezone if not given.
  *
  * @param locale `Intl` locale,
  * @returns A curried function that takes `Intl` format options and returns another curried function that takes a timezone and returns the final curried function that operates on JS `Date` objects
@@ -27,7 +27,7 @@ export type FormatInstantOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
  */
 export function formatInstant(locale: Intl.LocalesArgument = undefined): (
   options?: FormatInstantOptions,
-) => (timezone: string) => (instant: Date) => string {
+) => (timezone?: string) => (instant: Date) => string {
   return (options = { timeZoneName: "short" }) => (timezone) => (instant) =>
     instant.toLocaleString(locale, {
       ...options,

--- a/utils/formatInstant.ts
+++ b/utils/formatInstant.ts
@@ -8,7 +8,7 @@ export type FormatInstantOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
  * 1. `Intl` {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument | locale },
  *    defaults to system's locale if not given.
  * 2. `Intl` {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat | format options },
- *    defaults to include a "short" timezone-style if no options given.
+ *    defaults to include a "short" timezone-style unless `timeZoneName` is explicitly `undefined`.
  * 3. A named IANA timezone, defaults to system's timezone if not given.
  *
  * @param locale `Intl` locale,
@@ -30,6 +30,7 @@ export function formatInstant(locale?: Intl.LocalesArgument): (
 ) => (timezone?: string) => (instant: Date) => string {
   return (options = { timeZoneName: "short" }) => (timezone) => (instant) =>
     instant.toLocaleString(locale, {
+      timeZoneName: "short",
       ...options,
       timeZone: timezone,
     });

--- a/utils/formatInstant_test.ts
+++ b/utils/formatInstant_test.ts
@@ -1,5 +1,5 @@
 import { formatInstant } from "./formatInstant.ts";
-import { assertEquals } from "../dev_deps.ts";
+import { assert, assertEquals } from "../dev_deps.ts";
 
 Deno.test("returns localized string for English locale and UK timezone", () => {
   const instant = new Date("2023-06-10T13:20:30+0100");
@@ -36,4 +36,8 @@ Deno.test("ignores timezone in options", () => {
     ),
     "6/10/2023, 1:20:30 PM",
   );
+});
+
+Deno.test("accepts leaving all parameters empty", () => {
+  assert(formatInstant()()()(new Date()));
 });

--- a/utils/formatInstant_test.ts
+++ b/utils/formatInstant_test.ts
@@ -1,5 +1,5 @@
 import { formatInstant } from "./formatInstant.ts";
-import { assert, assertEquals } from "../dev_deps.ts";
+import { assertEquals } from "../dev_deps.ts";
 
 Deno.test("returns localized string for English locale and UK timezone", () => {
   const instant = new Date("2023-06-10T13:20:30+0100");
@@ -27,17 +27,41 @@ Deno.test("takes Intl options", () => {
   );
 });
 
-Deno.test("ignores timezone in options", () => {
+Deno.test("adds timeZoneName to options if left out", () => {
   const instant = new Date("2023-06-10T13:20:30+0100");
   assertEquals(
-    // @ts-ignore: Pass timeZone even if not allowed by type
-    formatInstant("en")({ timeZone: "America/Chicago" })("Europe/London")(
+    formatInstant("en")({ hourCycle: "h23" })("Europe/London")(
+      instant,
+    ),
+    "6/10/2023, 13:20:30 GMT+1",
+  );
+});
+
+Deno.test("doesn't add timeZoneName when explicitly set to undefined", () => {
+  const instant = new Date("2023-06-10T13:20:30+0100");
+  assertEquals(
+    formatInstant("en")({ timeZoneName: undefined })("Europe/London")(
       instant,
     ),
     "6/10/2023, 1:20:30 PM",
   );
 });
 
-Deno.test("accepts leaving all parameters empty", () => {
-  assert(formatInstant()()()(new Date()));
+Deno.test("ignores timeZone in options", () => {
+  const instant = new Date("2023-06-10T13:20:30+0100");
+  assertEquals(
+    // @ts-ignore: Pass timeZone even if not allowed by type
+    formatInstant("en")({ timeZone: "America/Chicago" })("Europe/London")(
+      instant,
+    ),
+    "6/10/2023, 1:20:30 PM GMT+1",
+  );
+});
+
+Deno.test("accepts leaving all parameters empty for system defaults and short timezone name", () => {
+  const instant = new Date("2023-06-10T13:20:30+0100");
+  assertEquals(
+    formatInstant()()()(instant),
+    instant.toLocaleString(undefined, { timeZoneName: "short" }),
+  );
 });


### PR DESCRIPTION
Change the API for `formatInstant`:

- Force `timeZoneName: "short"` into options unless it's explicitly `undefined` (breaking change)
- Fallback to system's timezone if parameter is left out