### PR TITLE
Don't hide object structure behind named types

### DIFF
--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -125,13 +125,11 @@ export interface ExtendedPlainDate extends ComPlainDate {
  * @param date A date object with properties `year`, `month` & `day`
  * @returns A new immutable extended plain-date object
  */
-export function ExPlainDate(
-  { year = NaN, month = 1, day = 1 }: {
-    year: number | string;
-    month?: number | string;
-    day?: number | string;
-  },
-): ExtendedPlainDate {
+export function ExPlainDate({ year, month = 1, day = 1 }: {
+  year: number | string;
+  month?: number | string;
+  day?: number | string;
+}): ExtendedPlainDate {
   const exPlainDate: ExtendedPlainDate = {
     ...PlainDate({ year, month, day }),
     constructor: ExPlainDate,

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -1,5 +1,5 @@
 import { ComPlainDate, PlainDate, PlainDateFactory } from "./PlainDate.ts";
-import { SloppyDate, SloppyTime } from "./support/date-time-types.ts";
+import { SloppyDate } from "./support/date-time-types.ts";
 import { createLocalInstant } from "./utils/createLocalInstant.ts";
 import { createInstant } from "./utils/createInstant.ts";
 import { QuarterNumber, WeekDay, WeekDayNumber } from "./constants.ts";
@@ -45,13 +45,23 @@ export interface ExtendedPlainDate extends ComPlainDate {
   /**
    * Get a native JS `Date` object in the system's local timezone.
    */
-  toLocalInstant: (time?: SloppyTime) => Date;
+  toLocalInstant: (time?: {
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  }) => Date;
   /**
    * Get a native JS `Date` object in a named timezone.
    *
    * @throws {RangeError} Invalid timezone specified
    */
-  toInstant: (timezone: string, time?: SloppyTime) => Date;
+  toInstant: (timezone: string, time?: {
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  }) => Date;
 
   toLocaleStringMedium: (locale?: Intl.LocalesArgument) => string;
   toLocaleStringLong: (locale?: Intl.LocalesArgument) => string;

--- a/ExPlainDate.ts
+++ b/ExPlainDate.ts
@@ -1,5 +1,4 @@
 import { ComPlainDate, PlainDate, PlainDateFactory } from "./PlainDate.ts";
-import { SloppyDate } from "./support/date-time-types.ts";
 import { createLocalInstant } from "./utils/createLocalInstant.ts";
 import { createInstant } from "./utils/createInstant.ts";
 import { QuarterNumber, WeekDay, WeekDayNumber } from "./constants.ts";
@@ -127,7 +126,11 @@ export interface ExtendedPlainDate extends ComPlainDate {
  * @returns A new immutable extended plain-date object
  */
 export function ExPlainDate(
-  { year = NaN, month = 1, day = 1 }: SloppyDate,
+  { year = NaN, month = 1, day = 1 }: {
+    year: number | string;
+    month?: number | string;
+    day?: number | string;
+  },
 ): ExtendedPlainDate {
   const exPlainDate: ExtendedPlainDate = {
     ...PlainDate({ year, month, day }),

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -1,5 +1,4 @@
 import { createUtcInstant } from "./utils/createUtcInstant.ts";
-import { SloppyDate } from "./support/date-time-types.ts";
 import { MonthNumber } from "./constants.ts";
 
 export type FormatPlainDateOptions = Omit<
@@ -83,7 +82,11 @@ export interface ComPlainDate {
    */
   map: <T extends ComPlainDate>(
     this: T,
-    f: (x: T) => SloppyDate,
+    f: (x: T) => {
+      year: number | string;
+      month?: number | string;
+      day?: number | string;
+    },
   ) => T;
 }
 
@@ -94,7 +97,11 @@ export interface ComPlainDate {
  * takes other kinds of arguments.
  */
 export interface PlainDateFactory<T extends ComPlainDate> {
-  (x: SloppyDate): T;
+  (x: {
+    year: number | string;
+    month?: number | string;
+    day?: number | string;
+  }): T;
   fromString?: <T extends ComPlainDate>(
     this: PlainDateFactory<T>,
     s: string,
@@ -121,7 +128,11 @@ export interface PlainDateFactory<T extends ComPlainDate> {
  * @returns A new immutable plain-date object
  */
 export function PlainDate(
-  { year = NaN, month = 1, day = 1 }: SloppyDate,
+  { year = NaN, month = 1, day = 1 }: {
+    year: number | string;
+    month?: number | string;
+    day?: number | string;
+  },
 ): ComPlainDate {
   const utcDate = createUtcInstant({ year, month, day });
 

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -77,15 +77,15 @@ export interface ComPlainDate {
   /**
    * Create a new plain-date object from this one, modified by a function.
    *
-   * @param f A function that takes a plain-date and returns a sloppy-date
-   * @returns A new plain-date made from the sloppy-date
+   * @param f A function that takes a plain-date and returns a date object with properties `year`, `month` & `day`
+   * @returns A new plain-date made from the date
    */
   map: <T extends ComPlainDate>(
     this: T,
     f: (x: T) => {
       year: number | string;
-      month?: number | string;
-      day?: number | string;
+      month: number | string;
+      day: number | string;
     },
   ) => T;
 }

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -127,13 +127,11 @@ export interface PlainDateFactory<T extends ComPlainDate> {
  * @param date A date object with properties `year`, `month` & `day`
  * @returns A new immutable plain-date object
  */
-export function PlainDate(
-  { year = NaN, month = 1, day = 1 }: {
-    year: number | string;
-    month?: number | string;
-    day?: number | string;
-  },
-): ComPlainDate {
+export function PlainDate({ year, month = 1, day = 1 }: {
+  year: number | string;
+  month?: number | string;
+  day?: number | string;
+}): ComPlainDate {
   const utcDate = createUtcInstant({ year, month, day });
 
   if (isNaN(utcDate.valueOf())) {

--- a/PlainDate.ts
+++ b/PlainDate.ts
@@ -1,5 +1,5 @@
 import { createUtcInstant } from "./utils/createUtcInstant.ts";
-import { SloppyDate, SloppyTime } from "./support/date-time-types.ts";
+import { SloppyDate } from "./support/date-time-types.ts";
 import { MonthNumber } from "./constants.ts";
 
 export type FormatPlainDateOptions = Omit<
@@ -55,7 +55,12 @@ export interface ComPlainDate {
   /**
    * Get a native JS `Date` object in UTC.
    */
-  toUtcInstant: (time?: SloppyTime) => Date;
+  toUtcInstant: (time?: {
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  }) => Date;
 
   constructor: PlainDateFactory<this>;
 

--- a/PlainTime.ts
+++ b/PlainTime.ts
@@ -1,4 +1,3 @@
-import { SloppyTime } from "./support/date-time-types.ts";
 import { HOURS_IN_DAY, MS_IN_HOUR } from "./constants.ts";
 import { tallyMilliseconds } from "./support/tallyMilliseconds.ts";
 
@@ -71,7 +70,12 @@ export interface ComPlainTime {
  * Describes a factory function that creates plain-time objects.
  */
 export interface PlainTimeFactory<T extends ComPlainTime> {
-  (x: SloppyTime): T;
+  (x: {
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  }): T;
 }
 
 /**
@@ -84,7 +88,12 @@ export interface PlainTimeFactory<T extends ComPlainTime> {
  * @throws {RangeError} Input total can't be negative
  */
 export function PlainTime(
-  { hour = 0, minute = 0, second = 0, millisecond = 0 }: SloppyTime,
+  { hour = 0, minute = 0, second = 0, millisecond = 0 }: {
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  },
 ): ComPlainTime {
   const ms = tallyMilliseconds({ hour, minute, second, millisecond });
 

--- a/mod.ts
+++ b/mod.ts
@@ -136,7 +136,6 @@ export {
 export type { MonthNumber, QuarterNumber, WeekDayNumber } from "./constants.ts";
 
 // Types
-export type { SplitDateTime } from "./support/date-time-types.ts";
 export type { PlainDateMapFn } from "./support/function-signatures.ts";
 
 // Utils for parsing strings into objects

--- a/mod.ts
+++ b/mod.ts
@@ -136,11 +136,7 @@ export {
 export type { MonthNumber, QuarterNumber, WeekDayNumber } from "./constants.ts";
 
 // Types
-export type {
-  SloppyDate,
-  SloppyDateTime,
-  SplitDateTime,
-} from "./support/date-time-types.ts";
+export type { SloppyDate, SplitDateTime } from "./support/date-time-types.ts";
 export type { PlainDateMapFn } from "./support/function-signatures.ts";
 
 // Utils for parsing strings into objects

--- a/mod.ts
+++ b/mod.ts
@@ -136,7 +136,7 @@ export {
 export type { MonthNumber, QuarterNumber, WeekDayNumber } from "./constants.ts";
 
 // Types
-export type { SloppyDate, SplitDateTime } from "./support/date-time-types.ts";
+export type { SplitDateTime } from "./support/date-time-types.ts";
 export type { PlainDateMapFn } from "./support/function-signatures.ts";
 
 // Utils for parsing strings into objects

--- a/mod.ts
+++ b/mod.ts
@@ -139,7 +139,6 @@ export type { MonthNumber, QuarterNumber, WeekDayNumber } from "./constants.ts";
 export type {
   SloppyDate,
   SloppyDateTime,
-  SloppyTime,
   SplitDateTime,
 } from "./support/date-time-types.ts";
 export type { PlainDateMapFn } from "./support/function-signatures.ts";

--- a/support/date-time-types.ts
+++ b/support/date-time-types.ts
@@ -1,13 +1,6 @@
 import { ComPlainDate } from "../PlainDate.ts";
 import { ComPlainTime } from "../PlainTime.ts";
 
-/** Describes a date where parts can be numbers or strings. */
-export type SloppyDate = {
-  year: number | string;
-  month?: number | string;
-  day?: number | string;
-};
-
 /** Describes a tuple of separate plain-date and plain-time objects. */
 export type SplitDateTime = [
   ComPlainDate,

--- a/support/date-time-types.ts
+++ b/support/date-time-types.ts
@@ -8,17 +8,6 @@ export type SloppyDate = {
   day?: number | string;
 };
 
-/** Describes a time where parts can be numbers or strings. */
-export type SloppyTime = {
-  hour?: number | string;
-  minute?: number | string;
-  second?: number | string;
-  millisecond?: number | string;
-};
-
-/** Describes a date-time where parts can be numbers or strings. */
-export type SloppyDateTime = SloppyDate & SloppyTime;
-
 /** Describes a tuple of separate plain-date and plain-time objects. */
 export type SplitDateTime = [
   ComPlainDate,

--- a/support/date-time-types.ts
+++ b/support/date-time-types.ts
@@ -1,8 +1,0 @@
-import { ComPlainDate } from "../PlainDate.ts";
-import { ComPlainTime } from "../PlainTime.ts";
-
-/** Describes a tuple of separate plain-date and plain-time objects. */
-export type SplitDateTime = [
-  ComPlainDate,
-  ComPlainTime,
-];

--- a/support/tallyMilliseconds.ts
+++ b/support/tallyMilliseconds.ts
@@ -1,5 +1,4 @@
 import { MS_IN_HOUR, MS_IN_MINUTE, MS_IN_SECOND } from "../constants.ts";
-import { SloppyTime } from "./date-time-types.ts";
 
 /**
  * Convert a sloppy time object to a total number of milliseconds.
@@ -9,7 +8,12 @@ export function tallyMilliseconds({
   minute = 0,
   second = 0,
   millisecond = 0,
-}: SloppyTime): number {
+}: {
+  hour?: number | string;
+  minute?: number | string;
+  second?: number | string;
+  millisecond?: number | string;
+}): number {
   return Number(hour) * MS_IN_HOUR + Number(minute) * MS_IN_MINUTE +
     Number(second) * MS_IN_SECOND + Number(millisecond);
 }

--- a/support/tallyMilliseconds.ts
+++ b/support/tallyMilliseconds.ts
@@ -1,7 +1,7 @@
 import { MS_IN_HOUR, MS_IN_MINUTE, MS_IN_SECOND } from "../constants.ts";
 
 /**
- * Convert a sloppy time object to a total number of milliseconds.
+ * Convert a time object to a total number of milliseconds.
  */
 export function tallyMilliseconds({
   hour = 0,

--- a/utils/addTime.ts
+++ b/utils/addTime.ts
@@ -1,4 +1,3 @@
-import { SloppyTime } from "../support/date-time-types.ts";
 import { tallyMilliseconds } from "../support/tallyMilliseconds.ts";
 
 /**
@@ -13,7 +12,12 @@ export function addTime({
   minute = 0,
   second = 0,
   millisecond = 0,
-}: SloppyTime) {
+}: {
+  hour?: number | string;
+  minute?: number | string;
+  second?: number | string;
+  millisecond?: number | string;
+}) {
   return (instant: Date): Date =>
     new Date(
       instant.valueOf() +

--- a/utils/createInstant.ts
+++ b/utils/createInstant.ts
@@ -39,7 +39,7 @@ export function createInstant(
 ) => Date {
   return (
     {
-      year = NaN,
+      year,
       month = 1,
       day = 1,
       hour = 0,

--- a/utils/createInstant.ts
+++ b/utils/createInstant.ts
@@ -5,7 +5,6 @@ import { intlParts } from "../support/intlParts.ts";
 import { timezoneOffsetParts } from "../support/timezoneOffsetParts.ts";
 import { HOURS_IN_DAY } from "../constants.ts";
 import { isTruthy } from "../support/isTruthy.ts";
-import { SloppyDateTime } from "../support/date-time-types.ts";
 
 const intlOptions: Intl.DateTimeFormatOptions = {
   hourCycle: "h23",
@@ -28,7 +27,15 @@ const intlOptions: Intl.DateTimeFormatOptions = {
 export function createInstant(
   timezone: string,
 ): (
-  { year, month, day, hour, minute, second, millisecond }: SloppyDateTime,
+  { year, month, day, hour, minute, second, millisecond }: {
+    year: number | string;
+    month?: number | string;
+    day?: number | string;
+    hour?: number | string;
+    minute?: number | string;
+    second?: number | string;
+    millisecond?: number | string;
+  },
 ) => Date {
   return (
     {

--- a/utils/createLocalInstant.ts
+++ b/utils/createLocalInstant.ts
@@ -1,5 +1,3 @@
-import { SloppyDateTime } from "../support/date-time-types.ts";
-
 /**
  * Create a native JS `Date` object from a date-time
  * interpreted in the system's local timezone.
@@ -12,7 +10,15 @@ export function createLocalInstant({
   minute = 0,
   second = 0,
   millisecond = 0,
-}: SloppyDateTime): Date {
+}: {
+  year: number | string;
+  month?: number | string;
+  day?: number | string;
+  hour?: number | string;
+  minute?: number | string;
+  second?: number | string;
+  millisecond?: number | string;
+}): Date {
   const localDate = new Date(0);
   localDate.setFullYear(Number(year), Number(month) - 1, Number(day));
   localDate.setHours(

--- a/utils/createLocalInstant.ts
+++ b/utils/createLocalInstant.ts
@@ -3,7 +3,7 @@
  * interpreted in the system's local timezone.
  */
 export function createLocalInstant({
-  year = NaN,
+  year,
   month = 1,
   day = 1,
   hour = 0,

--- a/utils/createUtcInstant.ts
+++ b/utils/createUtcInstant.ts
@@ -2,7 +2,7 @@
  * Create a native JS `Date` object from a date-time interpreted in UTC.
  */
 export function createUtcInstant({
-  year = NaN,
+  year,
   month = 1,
   day = 1,
   hour = 0,

--- a/utils/createUtcInstant.ts
+++ b/utils/createUtcInstant.ts
@@ -1,5 +1,3 @@
-import { SloppyDateTime } from "../support/date-time-types.ts";
-
 /**
  * Create a native JS `Date` object from a date-time interpreted in UTC.
  */
@@ -11,7 +9,15 @@ export function createUtcInstant({
   minute = 0,
   second = 0,
   millisecond = 0,
-}: SloppyDateTime): Date {
+}: {
+  year: number | string;
+  month?: number | string;
+  day?: number | string;
+  hour?: number | string;
+  minute?: number | string;
+  second?: number | string;
+  millisecond?: number | string;
+}): Date {
   const utcDate = new Date(0);
   utcDate.setUTCFullYear(Number(year), Number(month) - 1, Number(day));
   utcDate.setUTCHours(

--- a/utils/daysInMonth.ts
+++ b/utils/daysInMonth.ts
@@ -1,7 +1,7 @@
 import { PlainDate } from "../PlainDate.ts";
 
 /**
- * Get the number of days in a month for a given date.
+ * Get the number of days in the month for a given date.
  *
  * February has 29 days in a leap year, otherwise 28.
  */

--- a/utils/daysInMonth.ts
+++ b/utils/daysInMonth.ts
@@ -1,11 +1,13 @@
 import { PlainDate } from "../PlainDate.ts";
-import { SloppyDate } from "../support/date-time-types.ts";
 
 /**
- * Get the number of days in a month for a given year.
+ * Get the number of days in a month for a given date.
  *
  * February has 29 days in a leap year, otherwise 28.
  */
-export function daysInMonth({ year, month }: SloppyDate): number {
+export function daysInMonth({ year, month }: {
+  year: number | string;
+  month: number | string;
+}): number {
   return 32 - PlainDate({ year, month, day: 32 }).day;
 }

--- a/utils/daysInYear.ts
+++ b/utils/daysInYear.ts
@@ -1,12 +1,11 @@
 import { isLeapYear } from "./isLeapYear.ts";
 import { DAYS_IN_COMMON_YEAR, DAYS_IN_LEAP_YEAR } from "../constants.ts";
-import { SloppyDate } from "../support/date-time-types.ts";
 
 /**
- * Get the number of days in a given year.
+ * Get the number of days in the year of a given date.
  *
  * Leap years have 366 days, otherwise 365.
  */
-export function daysInYear({ year }: SloppyDate): number {
+export function daysInYear({ year }: { year: number | string }): number {
   return isLeapYear({ year }) ? DAYS_IN_LEAP_YEAR : DAYS_IN_COMMON_YEAR;
 }

--- a/utils/differenceInYears.ts
+++ b/utils/differenceInYears.ts
@@ -1,14 +1,12 @@
-import { SloppyDate } from "../support/date-time-types.ts";
-
 /**
- * Get a function curried with a plain-date, from which to get the number of
- * crossings over years between it and other plain-dates.
+ * Get a function curried with a date, from which to get the number of
+ * crossings over years between it and other dates.
  *
  * @param from A date to calculate the difference from
  * @returns A curried function that operates on dates
  */
 export function differenceInYears(
-  from: SloppyDate,
-): (to: SloppyDate) => number {
+  from: { year: number | string },
+): (to: { year: number | string }) => number {
   return (to) => Number(to.year) - Number(from.year);
 }

--- a/utils/formatDatetimeLocal.ts
+++ b/utils/formatDatetimeLocal.ts
@@ -9,7 +9,7 @@ import { createUtcInstant } from "./createUtcInstant.ts";
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local | HTML input datetime-local on MDN}
  */
 export function formatDatetimeLocal({
-  year = NaN,
+  year,
   month = 1,
   day = 1,
   hour = 0,

--- a/utils/formatDatetimeLocal.ts
+++ b/utils/formatDatetimeLocal.ts
@@ -1,4 +1,3 @@
-import { SloppyDateTime } from "../support/date-time-types.ts";
 import { createUtcInstant } from "./createUtcInstant.ts";
 
 /**
@@ -15,7 +14,13 @@ export function formatDatetimeLocal({
   day = 1,
   hour = 0,
   minute = 0,
-}: SloppyDateTime): string {
+}: {
+  year: number | string;
+  month?: number | string;
+  day?: number | string;
+  hour?: number | string;
+  minute?: number | string;
+}): string {
   if (Number(year) < 1) {
     throw new RangeError(
       `Years before 0001 can't be represented by HTML datetime-local: ${year}`,

--- a/utils/formatDatetimeLocal_test.ts
+++ b/utils/formatDatetimeLocal_test.ts
@@ -22,7 +22,9 @@ Deno.test("cuts off second and millisecond", () => {
       day: 3,
       hour: 4,
       minute: 5,
+      // @ts-ignore Override argument not allowed in type
       second: 6,
+      // @ts-ignore Override argument not allowed in type
       millisecond: 7,
     }),
     "2022-02-03T04:05",

--- a/utils/isFirstDayOfMonth.ts
+++ b/utils/isFirstDayOfMonth.ts
@@ -1,8 +1,6 @@
-import { SloppyDate } from "../support/date-time-types.ts";
-
 /**
  * Check if a date is the first day of its month.
  */
-export function isFirstDayOfMonth({ day }: SloppyDate): boolean {
+export function isFirstDayOfMonth({ day }: { day: number | string }): boolean {
   return Number(day) === 1;
 }

--- a/utils/isFirstDayOfMonth_test.ts
+++ b/utils/isFirstDayOfMonth_test.ts
@@ -2,9 +2,19 @@ import { isFirstDayOfMonth } from "./isFirstDayOfMonth.ts";
 import { assert, assertFalse } from "../dev_deps.ts";
 
 Deno.test("true for first day of month", () => {
-  assert(isFirstDayOfMonth({ year: 2023, month: 2, day: 1 }));
+  assert(isFirstDayOfMonth({
+    // @ts-ignore Override argument not allowed in type
+    year: 2023,
+    month: 2,
+    day: 1,
+  }));
 });
 
 Deno.test("false for last day of month", () => {
-  assertFalse(isFirstDayOfMonth({ year: 2023, month: 2, day: 28 }));
+  assertFalse(isFirstDayOfMonth({
+    // @ts-ignore Override argument not allowed in type
+    year: 2023,
+    month: 2,
+    day: 28,
+  }));
 });

--- a/utils/isFirstDayOfYear.ts
+++ b/utils/isFirstDayOfYear.ts
@@ -1,8 +1,9 @@
-import { SloppyDate } from "../support/date-time-types.ts";
-
 /**
  * Check if a date is the first day of its year.
  */
-export function isFirstDayOfYear({ month, day }: Partial<SloppyDate>): boolean {
+export function isFirstDayOfYear({ month, day }: {
+  month: number | string;
+  day: number | string;
+}): boolean {
   return Number(month) === 1 && Number(day) === 1;
 }

--- a/utils/isLastDayOfMonth.ts
+++ b/utils/isLastDayOfMonth.ts
@@ -1,9 +1,12 @@
-import { SloppyDate } from "../support/date-time-types.ts";
 import { daysInMonth } from "./daysInMonth.ts";
 
 /**
  * Check if a date is the last day of its month.
  */
-export function isLastDayOfMonth(date: SloppyDate): boolean {
-  return Number(date.day) === daysInMonth(date);
+export function isLastDayOfMonth({ year, month, day }: {
+  year: number | string;
+  month: number | string;
+  day: number | string;
+}): boolean {
+  return Number(day) === daysInMonth({ year, month });
 }

--- a/utils/isLastDayOfYear.ts
+++ b/utils/isLastDayOfYear.ts
@@ -1,8 +1,9 @@
-import { SloppyDate } from "../support/date-time-types.ts";
-
 /**
  * Check if a date is the last day of its year.
  */
-export function isLastDayOfYear({ month, day }: Partial<SloppyDate>): boolean {
+export function isLastDayOfYear({ month, day }: {
+  month: number | string;
+  day: number | string;
+}): boolean {
   return Number(month) === 12 && Number(day) === 31;
 }

--- a/utils/isLeapYear.ts
+++ b/utils/isLeapYear.ts
@@ -1,9 +1,8 @@
-import { SloppyDate } from "../support/date-time-types.ts";
 import { createUtcInstant } from "./createUtcInstant.ts";
 
 /**
  * Check if a date is in a leap year.
  */
-export function isLeapYear({ year }: SloppyDate): boolean {
+export function isLeapYear({ year }: { year: number | string }): boolean {
   return createUtcInstant({ year, month: 2, day: 29 }).getUTCDate() === 29;
 }

--- a/utils/splitDateTime.ts
+++ b/utils/splitDateTime.ts
@@ -1,6 +1,5 @@
-import { PlainDate } from "../PlainDate.ts";
-import { PlainTime } from "../PlainTime.ts";
-import { SplitDateTime } from "../support/date-time-types.ts";
+import { ComPlainDate, PlainDate } from "../PlainDate.ts";
+import { ComPlainTime, PlainTime } from "../PlainTime.ts";
 
 /**
  * Get a function curried with a timezone, to split native JS `Date` objects
@@ -13,7 +12,7 @@ import { SplitDateTime } from "../support/date-time-types.ts";
  */
 export function splitDateTime(
   timezone: string,
-): (instant?: Date) => SplitDateTime {
+): (instant?: Date) => [ComPlainDate, ComPlainTime] {
   return (instant) => {
     instant ??= new Date();
     const locale = "en";

--- a/utils/splitLocalDateTime.ts
+++ b/utils/splitLocalDateTime.ts
@@ -1,12 +1,13 @@
-import { PlainDate } from "../PlainDate.ts";
-import { PlainTime } from "../PlainTime.ts";
-import { SplitDateTime } from "../support/date-time-types.ts";
+import { ComPlainDate, PlainDate } from "../PlainDate.ts";
+import { ComPlainTime, PlainTime } from "../PlainTime.ts";
 
 /**
  * Split native JS `Date` objects into separate plain-date and plain-time parts
  * in the system's local timezone.
  */
-export function splitLocalDateTime(instant?: Date): SplitDateTime {
+export function splitLocalDateTime(
+  instant?: Date,
+): [ComPlainDate, ComPlainTime] {
   instant ??= new Date();
   return [
     PlainDate({

--- a/utils/splitUtcDateTime.ts
+++ b/utils/splitUtcDateTime.ts
@@ -1,12 +1,11 @@
-import { PlainDate } from "../PlainDate.ts";
-import { PlainTime } from "../PlainTime.ts";
-import { SplitDateTime } from "../support/date-time-types.ts";
+import { ComPlainDate, PlainDate } from "../PlainDate.ts";
+import { ComPlainTime, PlainTime } from "../PlainTime.ts";
 
 /**
  * Split native JS `Date` objects into separate
  * plain-date and plain-time parts in UTC.
  */
-export function splitUtcDateTime(instant?: Date): SplitDateTime {
+export function splitUtcDateTime(instant?: Date): [ComPlainDate, ComPlainTime] {
   instant ??= new Date();
   return [
     PlainDate({

--- a/utils/subtractTime.ts
+++ b/utils/subtractTime.ts
@@ -1,4 +1,3 @@
-import { SloppyTime } from "../support/date-time-types.ts";
 import { tallyMilliseconds } from "../support/tallyMilliseconds.ts";
 
 /**
@@ -13,7 +12,12 @@ export function subtractTime({
   minute = 0,
   second = 0,
   millisecond = 0,
-}: SloppyTime) {
+}: {
+  hour?: number | string;
+  minute?: number | string;
+  second?: number | string;
+  millisecond?: number | string;
+}) {
   return (instant: Date): Date =>
     new Date(
       instant.valueOf() -


### PR DESCRIPTION
Generated docs as well as IDE hints become clearer when types are not abstracted away.